### PR TITLE
Improve retriever

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -32,16 +32,18 @@ fn run() -> cli::Result<()> {
         _ => slog::Level::Trace,
     };
 
+    let offline = matches.is_present("offline");
+
     let logger = make_logger(min_log_level);
 
     match matches.subcommand() {
-        ("solve", Some(matches)) => cli::solve::run(matches, &logger),
-        ("upgrade", Some(matches)) => cli::upgrade::run(matches, &logger),
-        ("install", Some(matches)) => cli::install::run(matches, &logger),
-        ("uninstall", Some(matches)) => cli::uninstall::run(matches, &logger),
+        ("solve", Some(matches)) => cli::solve::run(matches, offline, &logger),
+        ("upgrade", Some(matches)) => cli::upgrade::run(matches, offline, &logger),
+        ("install", Some(matches)) => cli::install::run(matches, offline, &logger),
+        ("uninstall", Some(matches)) => cli::uninstall::run(matches, offline, &logger),
         ("new", Some(matches)) => cli::new::run(matches, &logger),
         ("completions", Some(matches)) => cli::completions::run(matches),
-        ("tree", Some(matches)) => cli::tree::run(matches, &logger),
+        ("tree", Some(matches)) => cli::tree::run(matches, offline, &logger),
         (cmd, matches) => panic!(
             "Received command {} with matches {:#?} but I don't know how to handle this",
             cmd, matches

--- a/src/lib/cli/mod.rs
+++ b/src/lib/cli/mod.rs
@@ -27,6 +27,12 @@ pub fn build() -> App<'static, 'static> {
                 .multiple(true)
                 .help("Sets the level of verbosity"),
         )
+        .arg(
+            Arg::with_name("offline")
+                .long("offline")
+                .multiple(false)
+                .help("Enable offline mode, which means no HTTP traffic will happen"),
+        )
         .subcommand(
             SubCommand::with_name("upgrade")
                 .about("Bring your dependencies up to date")

--- a/src/lib/cli/uninstall.rs
+++ b/src/lib/cli/uninstall.rs
@@ -12,16 +12,27 @@ use failure::ResultExt;
 use slog::Logger;
 use std::collections::{BTreeMap, HashSet};
 
-pub fn run(matches: &ArgMatches, logger: &Logger) -> Result<()> {
-    util::with_elm_json(&matches, &logger, uninstall_application, uninstall_package)
+pub fn run(matches: &ArgMatches, offline: bool, logger: &Logger) -> Result<()> {
+    util::with_elm_json(
+        &matches,
+        offline,
+        &logger,
+        uninstall_application,
+        uninstall_package,
+    )
 }
 
-fn uninstall_application(matches: &ArgMatches, logger: &Logger, info: Application) -> Result<()> {
+fn uninstall_application(
+    matches: &ArgMatches,
+    offline: bool,
+    logger: &Logger,
+    info: Application,
+) -> Result<()> {
     let strictness = semver::Strictness::Exact;
     let elm_version = info.elm_version();
 
     let mut retriever: Retriever =
-        Retriever::new(&logger, &elm_version.into()).context(ErrorKind::Unknown)?;
+        Retriever::new(&logger, &elm_version.into(), offline).context(ErrorKind::Unknown)?;
 
     let extras: HashSet<_> = matches
         .values_of_lossy("extra")
@@ -109,7 +120,12 @@ fn uninstall_application(matches: &ArgMatches, logger: &Logger, info: Applicatio
     Ok(())
 }
 
-fn uninstall_package(matches: &ArgMatches, _logger: &Logger, info: Package) -> Result<()> {
+fn uninstall_package(
+    matches: &ArgMatches,
+    _offline: bool,
+    _logger: &Logger,
+    info: Package,
+) -> Result<()> {
     let extras: HashSet<_> = matches
         .values_of_lossy("extra")
         .unwrap_or_else(Vec::new)

--- a/src/lib/cli/util.rs
+++ b/src/lib/cli/util.rs
@@ -24,17 +24,18 @@ pub fn confirm(prompt: &str, matches: &ArgMatches) -> Result<bool> {
 
 pub fn with_elm_json<A, P>(
     matches: &ArgMatches,
+    offline: bool,
     logger: &Logger,
     run_app: A,
     run_pkg: P,
 ) -> Result<()>
 where
-    A: FnOnce(&ArgMatches, &Logger, Application) -> Result<()>,
-    P: FnOnce(&ArgMatches, &Logger, Package) -> Result<()>,
+    A: FnOnce(&ArgMatches, bool, &Logger, Application) -> Result<()>,
+    P: FnOnce(&ArgMatches, bool, &Logger, Package) -> Result<()>,
 {
     match self::read_elm_json(&matches)? {
-        Project::Application(app) => run_app(&matches, &logger, app),
-        Project::Package(pkg) => run_pkg(&matches, &logger, pkg),
+        Project::Application(app) => run_app(&matches, offline, &logger, app),
+        Project::Package(pkg) => run_pkg(&matches, offline, &logger, pkg),
     }
 }
 

--- a/src/lib/package/retriever.rs
+++ b/src/lib/package/retriever.rs
@@ -135,12 +135,18 @@ impl Retriever {
                 );
                 HashMap::new()
             });
+
+            let mut changed = false;
+
             for (pkg, vs) in &remote_versions {
                 let entry = versions.entry(pkg.clone()).or_insert_with(Vec::new);
                 entry.extend(vs);
+                changed = true;
             }
 
-            self.save_cached_versions(&file, &versions)?;
+            if changed {
+                self.save_cached_versions(&file, &versions)?;
+            }
         }
 
         file.unlock()?;


### PR DESCRIPTION
- look at 0.19.1 paths for elm.json files, rather than only 0.19.0
- when we need to download an elm.json, store it on disk and reuse it in future runs
- only store versions.dat when changes are made, rather than always overwriting it
- add `--offline` mode which means no HTTP requests are made at all