### PR TITLE
Provide URL for FreeBSD amd64 binary

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ module.exports = binwrap({
     urls: {
         "darwin-arm64": root + "-x86_64-apple-darwin.tar.gz",
         "darwin-x64": root + "-x86_64-apple-darwin.tar.gz",
+        "freebsd-x64": root + "-x86_64-freebsd.tar.gz",
         "linux-x64": root + "-x86_64-unknown-linux-musl.tar.gz",
         "linux-arm": root + "-armv7-unknown-linux-musleabihf.tar.gz",
         "linux-arm64": root + "-armv7-unknown-linux-musleabihf.tar.gz",


### PR DESCRIPTION
Provide a compiled binary for the FreeBSD amd64 platform so that elm-json may be installed via npm using binwrap.

The attached binary was built on FreeBSD amd64 12.2-RELEASE-p1 using rustc v1.49.0 with the command:
`cargo build --release`
[elm-json-v0.2.10-x86_64-freebsd.tar.gz](https://github.com/zwilias/elm-json/files/5836323/elm-json-v0.2.10-x86_64-freebsd.tar.gz)
